### PR TITLE
Add lua support

### DIFF
--- a/lib/simplabs/highlight.rb
+++ b/lib/simplabs/highlight.rb
@@ -79,6 +79,7 @@ module Simplabs
       :java          => ['java'],
       :js            => ['javascript', 'js', 'jscript'],
       :jsp           => ['jsp'],
+      :lua           => ['lua'],
       :make          => ['make', 'basemake', 'makefile'],
       :nasm          => ['nasm', 'asm'],
       :'objective-c' => ['objective-c'],


### PR DESCRIPTION
Pygments supports lua. This wrapper does not. This pull request changes this.
